### PR TITLE
remove support of old interface of model constructors

### DIFF
--- a/test.blocks/test/test.common.js
+++ b/test.blocks/test/test.common.js
@@ -309,7 +309,20 @@ BN.addDecl('test', 'page', {
                     var model1 = BEM.blocks['nested-model'].create(),
                         model2 = BEM.blocks['model'].getAny(id1);
                     expect(model2).to.be.instanceof(BEM.blocks['model']);
-                })
+                });
+                it('should throw error if id attribute have not declared', function () {
+                    var model;
+
+                    expect(function () {
+                        var model = BEM.blocks['nested-model'].getAny(id1);
+                    }).to.throw(/should have declared id attribute/i);
+
+                    model = BEM.blocks['nested-model'].create();
+
+                    expect(function () {
+                        var model = BEM.blocks['nested-model'].getAny(id1);
+                    }).to.throw(/should have declared id attribute/i);
+                });
             });
 
             describe('server storage', function () {


### PR DESCRIPTION
Waiting for https://github.com/bem-node/promised-models/pull/23
After merge version of promised-models2 should be updated
